### PR TITLE
fix(pool): returning the pool out of the contructor

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -10,7 +10,7 @@ import (
 )
 
 func basicExample() {
-	if err := goredis.NewPool(
+	if _, err := goredis.NewPool(
 		goredis.WithMaxIdle(5),
 		goredis.WithMaxActive(10),
 		goredis.WithIdleTimeout(int(5*time.Minute)),

--- a/examples/viper.go
+++ b/examples/viper.go
@@ -14,7 +14,7 @@ func viperExample() {
 		panic(err)
 	}
 
-	if err := goredis.NewPool(
+	if _, err := goredis.NewPool(
 		goredis.FromViper(v)...,
 	); err != nil {
 		panic(err)

--- a/pool.go
+++ b/pool.go
@@ -46,8 +46,7 @@ type pool struct {
 }
 
 // NewPool returns a new Pool.
-func NewPool(connOpts ...PoolOption) error {
-
+func NewPool(connOpts ...PoolOption) (Pool, error) {
 	poolConn := &pool{
 		Pool: new(redis.Pool),
 	}
@@ -58,9 +57,9 @@ func NewPool(connOpts ...PoolOption) error {
 
 	switch {
 	case poolConn.addr == "":
-		return errors.New("no address provided")
+		return nil, errors.New("no address provided")
 	case poolConn.network == "":
-		return errors.New("no network provided")
+		return nil, errors.New("no network provided")
 	}
 
 	if poolConn.Dial == nil {
@@ -69,7 +68,7 @@ func NewPool(connOpts ...PoolOption) error {
 		}
 	}
 
-	return nil
+	return poolConn, nil
 }
 
 // Do will send a command to the server and returns the received reply on a connection from the pool.


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `NewPool` function in the `pool.go` file to improve its return type and error handling. The most important changes include modifying the return type to include a `Pool` and updating the error handling to return `nil` for the `Pool` when an error occurs.

Improvements to function return type and error handling:

* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L49-R49): Modified the `NewPool` function to return a `Pool` and an `error` instead of just an `error`.
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L61-R62): Updated the error handling in the `NewPool` function to return `nil` for the `Pool` when an error occurs, ensuring consistency in return types. [[1]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L61-R62) [[2]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L72-R71)