### PR TITLE
feat(logger): Passing custom logger

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -38,11 +38,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: "Configure git for private modules"
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -63,11 +58,6 @@ jobs:
           go-version: ${{ vars.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
 
-      - name: "Configure git for private modules"
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
-
       - name: Make
         run: make pr-approval
 
@@ -85,11 +75,6 @@ jobs:
         with:
           go-version: ${{ vars.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
-
-      - name: "Configure git for private modules"
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: "Run Code Generation"
         run: go generate ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,148 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+    - intrange
+    - testifylint
+    - perfsprint
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - revive
+      text: "^(enforce-slice-style|enforce-map-style)"
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true

--- a/pool.go
+++ b/pool.go
@@ -52,6 +52,7 @@ type pool struct {
 func NewPool(connOpts ...PoolOption) (Pool, error) {
 	poolConn := &pool{
 		Pool: new(redis.Pool),
+		l:    slog.Default(),
 	}
 
 	for _, opt := range connOpts {

--- a/pool.go
+++ b/pool.go
@@ -35,6 +35,9 @@ type Pool interface {
 type pool struct {
 	*redis.Pool
 
+	// l is the logger for the pool.
+	l *slog.Logger
+
 	// addr is the address of the redis server (host:port).
 	addr string
 
@@ -93,7 +96,7 @@ func (p *pool) DoCtx(ctx context.Context, command string, args ...any) (reply an
 
 	defer func(c redis.Conn) {
 		if err := c.Close(); err != nil {
-			slog.Error("error closing connection", slog.String(loggingKeyError, err.Error()))
+			p.l.Error("error closing connection", slog.String(loggingKeyError, err.Error()))
 		}
 	}(c)
 

--- a/pool_opts.go
+++ b/pool_opts.go
@@ -1,6 +1,7 @@
 package goredis
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -9,42 +10,56 @@ import (
 
 type PoolOption func(r *pool)
 
+// WithLogger is a PoolOption that sets the logger for the pool.
+func WithLogger(l *slog.Logger) PoolOption {
+	return func(r *pool) {
+		r.l = l
+	}
+}
+
+// WithMaxIdle is a PoolOption that sets the maximum number of idle connections in the pool.
 func WithMaxIdle(maxIdle int) PoolOption {
 	return func(r *pool) {
 		r.MaxIdle = maxIdle
 	}
 }
 
+// WithMaxActive is a PoolOption that sets the maximum number of active connections in the pool.
 func WithMaxActive(maxActive int) PoolOption {
 	return func(r *pool) {
 		r.MaxActive = maxActive
 	}
 }
 
+// WithIdleTimeout is a PoolOption that sets the idle timeout for connections in the pool.
 func WithIdleTimeout(idleTimeout int) PoolOption {
 	return func(r *pool) {
 		r.IdleTimeout = time.Duration(idleTimeout) * time.Second
 	}
 }
 
+// WithAddress is a PoolOption that sets the address of the redis server (host:port).
 func WithAddress(address string) PoolOption {
 	return func(r *pool) {
 		r.addr = address
 	}
 }
 
+// WithNetwork is a PoolOption that sets the network type to use when connecting to the redis server.
 func WithNetwork(network string) PoolOption {
 	return func(r *pool) {
 		r.network = network
 	}
 }
 
+// WithDialOpts is a PoolOption that sets the dial options to use when connecting to the redis server.
 func WithDialOpts(dialOpts ...redis.DialOption) PoolOption {
 	return func(r *pool) {
 		r.dialOpts = dialOpts
 	}
 }
 
+// FromViper returns a slice of PoolOptions from a viper instance.s
 func FromViper(v *viper.Viper) []PoolOption {
 	return []PoolOption{
 		WithMaxIdle(v.GetInt(viperMaxIdle)),


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the CI workflow configuration and the Go codebase. The main changes involve removing redundant steps from the CI workflow, adding new linters and their configurations, and enhancing the logging functionality in the Redis pool implementation.

### CI Workflow Improvements:
* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L41-L45): Removed redundant steps for configuring git for private modules. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L41-L45) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L66-L70) [[3]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L89-L93)

### Linter Configuration:
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R1-R148): Added new linters and their configurations to improve code quality and enforce coding standards.

### Logging Enhancements:
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R38-R40): Introduced a logger (`slog.Logger`) to the Redis pool and updated the `NewPool` function to initialize the logger. Updated the `DoCtx` method to use the pool's logger for error logging. [[1]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R38-R40) [[2]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2R55) [[3]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L96-R100)
* [`pool_opts.go`](diffhunk://#diff-3c6c76fbbc76e7f31d0a6d13347a768e10e1f14df5a261a3dae5e60ade9d57e2R4): Added a new `WithLogger` option to allow setting a custom logger for the Redis pool. [[1]](diffhunk://#diff-3c6c76fbbc76e7f31d0a6d13347a768e10e1f14df5a261a3dae5e60ade9d57e2R4) [[2]](diffhunk://#diff-3c6c76fbbc76e7f31d0a6d13347a768e10e1f14df5a261a3dae5e60ade9d57e2R13-R62)